### PR TITLE
Make the library compatible with swift and run BT in the background

### DIFF
--- a/IOS/BlunoBasicDemo/BlunoTest/Bluno/DFBlunoManager.h
+++ b/IOS/BlunoBasicDemo/BlunoTest/Bluno/DFBlunoManager.h
@@ -66,7 +66,7 @@
 [""] *
 [""] *	@return	void
 [""] */
--(void)didReceiveData:(NSData*)data Device:(DFBlunoDevice*)dev;
+-(void)didReceiveData:(NSData*)data device:(DFBlunoDevice*)dev;
 
 
 @end
@@ -74,6 +74,7 @@
 @interface DFBlunoManager : NSObject<CBCentralManagerDelegate,CBPeripheralDelegate>
 
 @property (nonatomic,weak) id<DFBlunoDelegate> delegate;
+@property (nonatomic) BOOL runOnMainThread; // defaults to YES
 
 /**
 [""] *	@brief	Singleton

--- a/IOS/BlunoBasicDemo/BlunoTest/Classes/VCMain.m
+++ b/IOS/BlunoBasicDemo/BlunoTest/Classes/VCMain.m
@@ -115,7 +115,7 @@
 {
     
 }
--(void)didReceiveData:(NSData*)data Device:(DFBlunoDevice*)dev
+-(void)didReceiveData:(NSData*)data device:(DFBlunoDevice*)dev
 {
     self.lbReceivedMsg.text = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }


### PR DESCRIPTION
To make the library compatible with _Swift_, I had to change the name of this method,
`-(void)didReceiveData:(NSData*)data Device:(DFBlunoDevice*)dev;`
to
`-(void)didReceiveData:(NSData*)data device:(DFBlunoDevice*)dev;`
(Native the lowercase `D` in device)
I also added a queue for the Bluetooth Networking, and added a property to make the callbacks happen on the main thread or background thread. For my personal use case, I need everything on a background thread.